### PR TITLE
Support configuring the access token server side

### DIFF
--- a/src/Huxley/Controllers/AllController.cs
+++ b/src/Huxley/Controllers/AllController.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Configuration;
 using System.Threading.Tasks;
 using System.Web.Http;
 using Huxley.ldbServiceReference;
@@ -9,6 +10,15 @@ namespace Huxley.Controllers {
         public async Task<StationBoard> Get(string id, Guid accessToken) {
 
             var client = new LDBServiceSoapClient();
+            var darwinAccessToken = ConfigurationManager.AppSettings["DarwinAccessToken"];
+            var clientAccessToken = ConfigurationManager.AppSettings["ClientAccessToken"];
+            Guid dat;
+            Guid cat;
+            if (Guid.TryParse(darwinAccessToken, out dat) &&
+                Guid.TryParse(clientAccessToken, out cat) &&
+                cat == accessToken) {
+                accessToken = dat;
+            }
             var token = new AccessToken { TokenValue = accessToken.ToString() };
 
             var board = await client.GetArrivalDepartureBoardAsync(token, 42, id.ToUpperInvariant(), null, FilterType.to, 0, 0);

--- a/src/Huxley/Controllers/AllController.cs
+++ b/src/Huxley/Controllers/AllController.cs
@@ -1,25 +1,14 @@
 ﻿using System;
-using System.Configuration;
 using System.Threading.Tasks;
-using System.Web.Http;
 using Huxley.ldbServiceReference;
 
 namespace Huxley.Controllers {
-    public class AllController : ApiController {
+    public class AllController : BaseController {
         // GET /all/CRS?accessToken=[your token]
         public async Task<StationBoard> Get(string id, Guid accessToken) {
 
             var client = new LDBServiceSoapClient();
-            var darwinAccessToken = ConfigurationManager.AppSettings["DarwinAccessToken"];
-            var clientAccessToken = ConfigurationManager.AppSettings["ClientAccessToken"];
-            Guid dat;
-            Guid cat;
-            if (Guid.TryParse(darwinAccessToken, out dat) &&
-                Guid.TryParse(clientAccessToken, out cat) &&
-                cat == accessToken) {
-                accessToken = dat;
-            }
-            var token = new AccessToken { TokenValue = accessToken.ToString() };
+            var token = MakeAccessToken(accessToken);
 
             var board = await client.GetArrivalDepartureBoardAsync(token, 42, id.ToUpperInvariant(), null, FilterType.to, 0, 0);
             return board.GetStationBoardResult;

--- a/src/Huxley/Controllers/ArrivalsController.cs
+++ b/src/Huxley/Controllers/ArrivalsController.cs
@@ -1,25 +1,14 @@
 ﻿using System;
-using System.Configuration;
 using System.Threading.Tasks;
-using System.Web.Http;
 using Huxley.ldbServiceReference;
 
 namespace Huxley.Controllers {
-    public class ArrivalsController : ApiController {
+    public class ArrivalsController : BaseController {
         // GET /arrivals/CRS?accessToken=[your token]
         public async Task<StationBoard> Get(string id, Guid accessToken) {
 
             var client = new LDBServiceSoapClient();
-            var darwinAccessToken = ConfigurationManager.AppSettings["DarwinAccessToken"];
-            var clientAccessToken = ConfigurationManager.AppSettings["ClientAccessToken"];
-            Guid dat;
-            Guid cat;
-            if (Guid.TryParse(darwinAccessToken, out dat) &&
-                Guid.TryParse(clientAccessToken, out cat) &&
-                cat == accessToken) {
-                accessToken = dat;
-            }
-            var token = new AccessToken { TokenValue = accessToken.ToString() };
+            var token = MakeAccessToken(accessToken);
 
             var board = await client.GetArrivalBoardAsync(token, 42, id.ToUpperInvariant(), null, FilterType.to, 0, 0);
             return board.GetStationBoardResult;

--- a/src/Huxley/Controllers/ArrivalsController.cs
+++ b/src/Huxley/Controllers/ArrivalsController.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Configuration;
 using System.Threading.Tasks;
 using System.Web.Http;
 using Huxley.ldbServiceReference;
@@ -9,6 +10,15 @@ namespace Huxley.Controllers {
         public async Task<StationBoard> Get(string id, Guid accessToken) {
 
             var client = new LDBServiceSoapClient();
+            var darwinAccessToken = ConfigurationManager.AppSettings["DarwinAccessToken"];
+            var clientAccessToken = ConfigurationManager.AppSettings["ClientAccessToken"];
+            Guid dat;
+            Guid cat;
+            if (Guid.TryParse(darwinAccessToken, out dat) &&
+                Guid.TryParse(clientAccessToken, out cat) &&
+                cat == accessToken) {
+                accessToken = dat;
+            }
             var token = new AccessToken { TokenValue = accessToken.ToString() };
 
             var board = await client.GetArrivalBoardAsync(token, 42, id.ToUpperInvariant(), null, FilterType.to, 0, 0);

--- a/src/Huxley/Controllers/BaseController.cs
+++ b/src/Huxley/Controllers/BaseController.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Configuration;
+using System.Web.Http;
+using Huxley.ldbServiceReference;
+
+namespace Huxley.Controllers {
+    public class BaseController : ApiController {
+        protected static AccessToken MakeAccessToken(Guid accessToken) {
+            var darwinAccessToken = ConfigurationManager.AppSettings["DarwinAccessToken"];
+            var clientAccessToken = ConfigurationManager.AppSettings["ClientAccessToken"];
+            Guid dat;
+            Guid cat;
+            if (Guid.TryParse(darwinAccessToken, out dat) &&
+                Guid.TryParse(clientAccessToken, out cat) &&
+                cat == accessToken) {
+                accessToken = dat;
+            }
+            var token = new AccessToken { TokenValue = accessToken.ToString() };
+            return token;
+        }
+
+    }
+}

--- a/src/Huxley/Controllers/DeparturesController.cs
+++ b/src/Huxley/Controllers/DeparturesController.cs
@@ -1,25 +1,14 @@
 ﻿using System;
-using System.Configuration;
 using System.Threading.Tasks;
-using System.Web.Http;
 using Huxley.ldbServiceReference;
 
 namespace Huxley.Controllers {
-    public class DeparturesController : ApiController {
+    public class DeparturesController : BaseController {
         // GET /departures/CRS?accessToken=[your token]
         public async Task<StationBoard> Get(string id, Guid accessToken) {
 
             var client = new LDBServiceSoapClient();
-            var darwinAccessToken = ConfigurationManager.AppSettings["DarwinAccessToken"];
-            var clientAccessToken = ConfigurationManager.AppSettings["ClientAccessToken"];
-            Guid dat;
-            Guid cat;
-            if (Guid.TryParse(darwinAccessToken, out dat) &&
-                Guid.TryParse(clientAccessToken, out cat) &&
-                cat == accessToken) {
-                accessToken = dat;
-            }
-            var token = new AccessToken { TokenValue = accessToken.ToString() };
+            var token = MakeAccessToken(accessToken);
 
             var board = await client.GetDepartureBoardAsync(token, 42, id.ToUpperInvariant(), null, FilterType.to, 0, 0);
             return board.GetStationBoardResult;

--- a/src/Huxley/Controllers/DeparturesController.cs
+++ b/src/Huxley/Controllers/DeparturesController.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Configuration;
 using System.Threading.Tasks;
 using System.Web.Http;
 using Huxley.ldbServiceReference;
@@ -9,6 +10,15 @@ namespace Huxley.Controllers {
         public async Task<StationBoard> Get(string id, Guid accessToken) {
 
             var client = new LDBServiceSoapClient();
+            var darwinAccessToken = ConfigurationManager.AppSettings["DarwinAccessToken"];
+            var clientAccessToken = ConfigurationManager.AppSettings["ClientAccessToken"];
+            Guid dat;
+            Guid cat;
+            if (Guid.TryParse(darwinAccessToken, out dat) &&
+                Guid.TryParse(clientAccessToken, out cat) &&
+                cat == accessToken) {
+                accessToken = dat;
+            }
             var token = new AccessToken { TokenValue = accessToken.ToString() };
 
             var board = await client.GetDepartureBoardAsync(token, 42, id.ToUpperInvariant(), null, FilterType.to, 0, 0);

--- a/src/Huxley/Controllers/ServiceController.cs
+++ b/src/Huxley/Controllers/ServiceController.cs
@@ -1,11 +1,9 @@
 ﻿using System;
-using System.Configuration;
 using System.Threading.Tasks;
-using System.Web.Http;
 using Huxley.ldbServiceReference;
 
 namespace Huxley.Controllers {
-    public class ServiceController : ApiController {
+    public class ServiceController : BaseController {
         // GET /service/ID?accessToken=[your token]
         public async Task<ServiceDetails> Get(string id, Guid accessToken) {
 
@@ -15,16 +13,7 @@ namespace Huxley.Controllers {
             }
 
             var client = new LDBServiceSoapClient();
-            var darwinAccessToken = ConfigurationManager.AppSettings["DarwinAccessToken"];
-            var clientAccessToken = ConfigurationManager.AppSettings["ClientAccessToken"];
-            Guid dat;
-            Guid cat;
-            if (Guid.TryParse(darwinAccessToken, out dat) &&
-                Guid.TryParse(clientAccessToken, out cat) &&
-                cat == accessToken) {
-                accessToken = dat;
-            }
-            var token = new AccessToken { TokenValue = accessToken.ToString() };
+            var token = MakeAccessToken(accessToken);
 
             var service = await client.GetServiceDetailsAsync(token, id);
             return service.GetServiceDetailsResult;

--- a/src/Huxley/Controllers/ServiceController.cs
+++ b/src/Huxley/Controllers/ServiceController.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Configuration;
 using System.Threading.Tasks;
 using System.Web.Http;
 using Huxley.ldbServiceReference;
@@ -14,6 +15,15 @@ namespace Huxley.Controllers {
             }
 
             var client = new LDBServiceSoapClient();
+            var darwinAccessToken = ConfigurationManager.AppSettings["DarwinAccessToken"];
+            var clientAccessToken = ConfigurationManager.AppSettings["ClientAccessToken"];
+            Guid dat;
+            Guid cat;
+            if (Guid.TryParse(darwinAccessToken, out dat) &&
+                Guid.TryParse(clientAccessToken, out cat) &&
+                cat == accessToken) {
+                accessToken = dat;
+            }
             var token = new AccessToken { TokenValue = accessToken.ToString() };
 
             var service = await client.GetServiceDetailsAsync(token, id);

--- a/src/Huxley/Huxley.csproj
+++ b/src/Huxley/Huxley.csproj
@@ -83,6 +83,7 @@
   <ItemGroup>
     <Compile Include="Controllers\ArrivalsController.cs" />
     <Compile Include="Controllers\AllController.cs" />
+    <Compile Include="Controllers\BaseController.cs" />
     <Compile Include="Controllers\ServiceController.cs" />
     <Compile Include="WebApiConfig.cs" />
     <Compile Include="Controllers\DeparturesController.cs" />

--- a/src/Huxley/Web.config
+++ b/src/Huxley/Web.config
@@ -1,5 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
+  <appSettings>
+    <add key="DarwinAccessToken" value="" />
+  </appSettings>
   <system.web>
     <customErrors mode="On" />
     <compilation targetFramework="4.5" />

--- a/src/Huxley/Web.config
+++ b/src/Huxley/Web.config
@@ -2,6 +2,7 @@
 <configuration>
   <appSettings>
     <add key="DarwinAccessToken" value="" />
+    <add key="ClientAccessToken" value="" />
   </appSettings>
   <system.web>
     <customErrors mode="On" />


### PR DESCRIPTION
Add support for configuring the Darwin access token server side so it doesn't need to be provided in the URL.
Addresses this issue: https://github.com/jpsingleton/Huxley/issues/12
